### PR TITLE
Remove movie-generation depencencies

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -28,11 +28,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[test]
-    - name: Install package dependencies
-      uses: cdw/get-package@master
-      with:
-        brew: ffmpeg librsvg
-        apt-get: ffmpeg librsvg2-bin
     - name: Test with pytest
       run: |
         pytest tests/

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -20,11 +20,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[test]
-    - name: Install package dependencies
-      uses: mstksg/get-package@v1
-      with:
-        brew: ffmpeg librsvg
-        apt-get: ffmpeg librsvg2-bin
     - name: Test with pytest
       run: |
         pytest tests/


### PR DESCRIPTION
From the testing environment. This is mostly b/c installing ffmpeg, even via brew, on macos is unreliable.

**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
